### PR TITLE
Make the library encoding-agnostic by making it expect and return bytes

### DIFF
--- a/multihash/multihash.py
+++ b/multihash/multihash.py
@@ -56,6 +56,7 @@ class MultiHash(_MultiHash):  # NOQA
 
 
 def decode(mh_bytes):
+    ensure_byteness(mh_bytes)
     len_mh_bytes = len(mh_bytes)
     if len_mh_bytes > 127:
         fmt_str = 'Multihash {0} bytes long. Must be < 129 bytes'

--- a/test/test_decode.py
+++ b/test/test_decode.py
@@ -1,17 +1,18 @@
-import six
 import pytest
 import multihash
 
+
 def test_decode_sha1():
-    mh_bytes = six.b('\x11(86f7e437faa5a7fce15d1ddcb9eaeaea377667b8')
+    mh_bytes = b'\x11(86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
     mh = multihash.decode(mh_bytes)
     assert mh.name == 'sha1'
     assert mh.length == 40
     assert mh.code == 0x11
-    assert mh.digest == '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
+    assert mh.digest == b'86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
+
 
 @pytest.mark.parametrize('mh_bytes,exception', (
-    (six.b('\x11d' + 'a' * 10), multihash.exceptions.InconsistentLen),
+    (b'\x11d' + b'a' * 10, multihash.exceptions.InconsistentLen),
 ))
 def test_decode_raises(mh_bytes, exception):
     with pytest.raises(exception):

--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -1,4 +1,7 @@
 # coding: utf-8
+
+import six
+
 import multihash
 
 
@@ -13,7 +16,9 @@ def test_encode_sha1_nolen():
 
 
 def test_encode_sha1_utf8():
-    digest = u'💻'.encode('utf-8')
+    digest = '💻'
+    if six.PY3:
+        digest = digest.encode('utf-8')
     mh = multihash.MultiHash('sha1', digest)
     encoded = mh.encode()
     assert encoded == b'\x11\x04\xf0\x9f\x92\xbb'

--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -1,21 +1,20 @@
 # coding: utf-8
-import six
 import multihash
 
 
 def test_encode_sha1():
-    mh = multihash.MultiHash('sha1', 'a', 1)
-    assert mh.encode() == six.b('\x11\x01a')
+    mh = multihash.MultiHash('sha1', b'a', 1)
+    assert mh.encode() == b'\x11\x01a'
 
 
 def test_encode_sha1_nolen():
-    mh = multihash.MultiHash('sha1', 'a')
-    assert mh.encode() == six.b('\x11\x01a')
+    mh = multihash.MultiHash('sha1', b'a')
+    assert mh.encode() == b'\x11\x01a'
 
 
 def test_encode_sha1_utf8():
-    digest = '💻'
+    digest = u'💻'.encode('utf-8')
     mh = multihash.MultiHash('sha1', digest)
     encoded = mh.encode()
-    assert encoded == six.b('\x11\x04\xf0\x9f\x92\xbb')
+    assert encoded == b'\x11\x04\xf0\x9f\x92\xbb'
     assert multihash.decode(encoded).digest == digest

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -1,23 +1,25 @@
 import pytest
 import multihash
 
+
 @pytest.mark.parametrize('args,exception', (
-    (('frob-35', 'a'), multihash.exceptions.UnknownCode),
-    (('sha1', 'a', 100), multihash.exceptions.InconsistentLen),
-    (('sha1', 'a' * 200, 200), multihash.exceptions.LenNotSupported),
-    (('sha1', 'a' * 200), multihash.exceptions.LenNotSupported),
+    (('frob-35', b'a'), multihash.exceptions.UnknownCode),
+    (('sha1', b'a', 100), multihash.exceptions.InconsistentLen),
+    (('sha1', b'a' * 200, 200), multihash.exceptions.LenNotSupported),
+    (('sha1', b'a' * 200), multihash.exceptions.LenNotSupported),
 ))
 def test_decode_raises(args, exception):
     with pytest.raises(exception):
         multihash.MultiHash(*args)
 
+
 def test_object_eq():
-    a = multihash.MultiHash('sha1', 'a')
-    b = multihash.MultiHash('sha1', 'a')
+    a = multihash.MultiHash('sha1', b'a')
+    b = multihash.MultiHash('sha1', b'a')
     assert a == b
 
 
 def test_object_neq():
-    a = multihash.MultiHash('sha1', 'a')
-    b = multihash.MultiHash('sha1', 'b')
+    a = multihash.MultiHash('sha1', b'a')
+    b = multihash.MultiHash('sha1', b'b')
     assert a != b


### PR DESCRIPTION
Hash libraries should not concern themselves with encodings. None of python's built-in hash functions care about encodings. They all expect bytes. In Python2 they expect str which is Python2's equivalent of bytes.
